### PR TITLE
Fix broken Markdown headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,48 +4,48 @@ The repository that contains the algorithms for generating domain names, diction
 Developed to research the possibility of applying machine learning and neural networks to detect and classify malicious domains.
 List of wordlist's
 -
-#####alexa.csv
+##### alexa.csv
 ```
 alexa top million
 ```
-#####opendns-top-domains.txt
+##### opendns-top-domains.txt
 ```
 a few dns domain's from opendns
 ```
-#####zeus.txt
+##### zeus.txt
 ```
 domain's from GameoverZeus.py http://garage4hackers.com/entry.php?b=3081
 ```
-#####cryptolocker.txt
+##### cryptolocker.txt
 ```
 domain's from Сryptolocker.pl
 ```
-#####pushdo.txt
+##### pushdo.txt
 ```
 domain's from PushDo.py http://www.garage4hackers.com/entry.php?b=3080
 ```
-#####rovnix.txt
+##### rovnix.txt
 ```
 https://www.csis.dk/en/csis/news/4472/
 http://www.constitution.org/usdeclar.txt
 ```
-#####conficker.txt
+##### conficker.txt
 ```
 domain's from Conficker.c
 ```
-#####tinba.txt
+##### tinba.txt
 ```
 domain's from Tinba.py http://garage4hackers.com/entry.php?b=3086
 ```
-#####matsnu.txt
+##### matsnu.txt
 ```
 domain's from Matsnu.py http://www.seculert.com/blog/2014/11/dgas-a-domain-generation-evolution.html
 ```
-#####ramdo.txt
+##### ramdo.txt
 ```
 domain's from Ramdo.cpp
 ```
-#####the translation from id to name
+##### the translation from id to name
 ```
 0 - legit
 1 - cryptolocker


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles [bryant1410/readmesfix#1](https://github.com/bryant1410/readmesfix/issues/1)